### PR TITLE
Add resilient authentication and safer rollcall handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,28 @@
 pip install xmu-rollcall-cli
 ```
 
+For the optional interactive browser-login fallback:
+
+```bash
+pip install 'xmu-rollcall-cli[browser]'
+playwright install chromium
+```
+
+Browser login requires Python 3.8 or newer.
+
 ## Usage
 
 ```bash
 xmu config  # configure your account. support multiple accounts.
 xmu switch  # switch between accounts.
-xmu start   # start the monitor.
+xmu start   # start the monitor; waits for 20% attendance by default.
+xmu auth import --file cookies.json  # import an authenticated cookie export.
+xmu auth browser  # open the official login page and capture its cookies.
 ```
+
+Manual self-registration rollcalls are supported. Use
+`xmu start --attendance-threshold 0` to disable the attendance delay. Never
+share cookie files; they grant access to your active session.
 
 ## Other
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,13 +30,28 @@
 pip install xmu-rollcall-cli
 ```
 
+如需使用桌面浏览器登录回退：
+
+```bash
+pip install 'xmu-rollcall-cli[browser]'
+playwright install chromium
+```
+
+浏览器登录回退需要 Python 3.8 或更高版本。
+
 ## 使用方法
 
 ```bash
 xmu config  # 配置账号。使用统一身份认证账号密码。
 xmu switch  # 切换账号。
-xmu start   # 启动监控。
+xmu start   # 启动监控，默认等待班级 20% 的同学完成签到。
+xmu auth import --file cookies.json  # 导入已登录的 Cookie。
+xmu auth browser  # 打开官方登录页并捕获登录后的 Cookie。
 ```
+
+现已支持自主点名。可用 `xmu start --attendance-threshold 0` 关闭延迟签到。
+移动端或沙盒环境无法拉起浏览器时请使用 Cookie 导入。Cookie 等同于登录凭据，
+请勿上传到 issue 或提供给他人。
 
 ## 其他
 

--- a/xmu-rollcall-cli/README.md
+++ b/xmu-rollcall-cli/README.md
@@ -11,8 +11,11 @@ A command-line tool for monitoring and auto-answering Tronclass rollcalls at Xia
 - Automatic handling for:
   - Number rollcalls (fetch number code and answer directly)
   - Radar rollcalls (location solving)
+  - Manual self-registration rollcalls
+- Wait until 20% of the class has signed before answering (configurable)
 - Multi-account management in one local config
 - Session cookie cache and refresh support
+- Cookie import and interactive browser-login fallbacks
 
 ## Installation
 
@@ -54,11 +57,52 @@ xmu start
 xmu refresh
 ```
 
+By default the bot waits until at least 20% of students have signed. Override
+the configured value for one run with:
+
+```bash
+xmu start --attendance-threshold 0.3
+```
+
+Use `0` to disable the delay. The bot keeps waiting when the attendance API is
+unavailable, so it does not sign early by accident.
+
+## Login fallbacks
+
+If password login is challenged, import cookies from a JSON export or raw
+`Cookie` header. The file may contain a `{name: value}` object, a list of
+browser cookie objects, or `{"cookies": [...]}`:
+
+```bash
+xmu auth import --file cookies.json
+```
+
+Without `--file`, the command securely prompts for pasted cookie content. Never
+post your cookies in an issue or send them to another person.
+
+On a desktop, the optional browser flow opens the official XMU/TronClass login
+page and captures the authenticated cookies after you finish any login or QR
+steps shown there:
+
+```bash
+pip install 'xmu-rollcall-cli[browser]'
+playwright install chromium
+xmu auth browser
+```
+
+The browser fallback requires Python 3.8 or newer. Core CLI and cookie import
+support remain available on Python 3.7.
+
+Browser launching may be unavailable in mobile shells and sandboxed
+environments; use cookie import there.
+
 ## Commands
 
 - `xmu config` - Add/delete accounts and set current account
 - `xmu switch` - Switch the current account
 - `xmu start` - Start rollcall monitoring loop
+- `xmu auth import` - Import an authenticated browser cookie export
+- `xmu auth browser` - Log in through an interactive Chromium window
 - `xmu refresh` - Remove cached cookies for current account
 - `xmu --help` - Show help
 

--- a/xmu-rollcall-cli/pyproject.toml
+++ b/xmu-rollcall-cli/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "aiohttp>=3.9.0",
 ]
 
+[project.optional-dependencies]
+browser = ["playwright>=1.40.0; python_version >= '3.8'"]
+
 [project.urls]
 Homepage = "https://github.com/KrsMt-0113/XMU-Rollcall-Bot"
 Repository = "https://github.com/KrsMt-0113/XMU-Rollcall-Bot"

--- a/xmu-rollcall-cli/setup.py
+++ b/xmu-rollcall-cli/setup.py
@@ -41,6 +41,9 @@ setup(
         "click>=8.1.0",
         "aiohttp>=3.9.0",
     ],
+    extras_require={
+        "browser": ["playwright>=1.40.0; python_version >= '3.8'"],
+    },
 
     # Entry points
     entry_points={

--- a/xmu-rollcall-cli/tests/test_auth.py
+++ b/xmu-rollcall-cli/tests/test_auth.py
@@ -1,0 +1,42 @@
+import json
+import unittest
+
+from xmu_rollcall.auth import CookieImportError, session_from_cookie_input
+
+
+class CookieImportTests(unittest.TestCase):
+    def test_raw_cookie_header(self):
+        session = session_from_cookie_input("Cookie: session=abc; role_token=student")
+
+        self.assertEqual(session.cookies.get("session"), "abc")
+        self.assertEqual(session.cookies.get("role_token"), "student")
+
+    def test_browser_json_export(self):
+        cookie_input = json.dumps(
+            {
+                "cookies": [
+                    {
+                        "name": "session",
+                        "value": "abc",
+                        "domain": "lnt.xmu.edu.cn",
+                        "path": "/",
+                        "secure": True,
+                    }
+                ]
+            }
+        )
+
+        session = session_from_cookie_input(cookie_input)
+
+        self.assertEqual(
+            session.cookies.get("session", domain="lnt.xmu.edu.cn", path="/"),
+            "abc",
+        )
+
+    def test_rejects_empty_json(self):
+        with self.assertRaises(CookieImportError):
+            session_from_cookie_input("{}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xmu-rollcall-cli/tests/test_config.py
+++ b/xmu-rollcall-cli/tests/test_config.py
@@ -1,0 +1,32 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from xmu_rollcall import config
+
+
+class ConfigTests(unittest.TestCase):
+    def test_missing_config_returns_fresh_defaults(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_dir = Path(temp_dir)
+            with patch.object(config, "CONFIG_DIR", config_dir), patch.object(
+                config, "CONFIG_FILE", config_dir / "config.json"
+            ):
+                first = config.load_config()
+                first["accounts"].append({"id": 1})
+                second = config.load_config()
+
+        self.assertEqual(second["accounts"], [])
+        self.assertEqual(second["attendance_threshold"], 0.2)
+
+    def test_invalid_threshold_uses_default(self):
+        self.assertEqual(config.get_attendance_threshold({"attendance_threshold": 2}), 0.2)
+        self.assertEqual(
+            config.get_attendance_threshold({"attendance_threshold": "invalid"}),
+            0.2,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xmu-rollcall-cli/tests/test_rollcall_handler.py
+++ b/xmu-rollcall-cli/tests/test_rollcall_handler.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import patch
+
+from xmu_rollcall.rollcall_handler import (
+    extract_rollcalls,
+    handle_rollcalls,
+    process_rollcalls,
+)
+
+
+SELF_REGISTRATION = {
+    "rollcalls": [
+        {
+            "id": 123,
+            "course_title": "Test course",
+            "created_by_name": "Teacher",
+            "department_name": "Department",
+            "is_expired": False,
+            "is_number": False,
+            "is_radar": False,
+            "rollcall_status": "in_progress",
+            "scored": True,
+            "source": "manual",
+            "type": "self_registration",
+            "status": "absent",
+        }
+    ]
+}
+
+
+class RollcallHandlerTests(unittest.TestCase):
+    def test_extracts_self_registration_and_id_fallback(self):
+        count, rollcalls = extract_rollcalls(SELF_REGISTRATION)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(rollcalls[0]["rollcall_id"], 123)
+        self.assertEqual(rollcalls[0]["type"], "self_registration")
+
+    @patch("xmu_rollcall.rollcall_handler.attendance_threshold_reached")
+    def test_already_answered_bypasses_threshold(self, threshold):
+        data = {"rollcalls": [dict(SELF_REGISTRATION["rollcalls"][0], status="on_call")]}
+
+        result = handle_rollcalls(data, object(), 0.2)
+
+        self.assertEqual(result, [True])
+        threshold.assert_not_called()
+
+    @patch("xmu_rollcall.rollcall_handler.send_self_registration", return_value=True)
+    @patch(
+        "xmu_rollcall.rollcall_handler.attendance_threshold_reached",
+        return_value=(True, {"student_rollcalls": []}),
+    )
+    def test_answers_self_registration_after_threshold(self, threshold, send):
+        session = object()
+        result = handle_rollcalls(SELF_REGISTRATION, session, 0.2)
+
+        self.assertEqual(result, [True])
+        threshold.assert_called_once_with(session, 123, 0.2)
+        send.assert_called_once_with(session, 123)
+
+    @patch(
+        "xmu_rollcall.rollcall_handler.attendance_threshold_reached",
+        return_value=(False, {"student_rollcalls": []}),
+    )
+    def test_pending_rollcall_is_retried(self, threshold):
+        result = process_rollcalls(SELF_REGISTRATION, object(), 0.2)
+
+        self.assertEqual(result, {"rollcalls": []})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xmu-rollcall-cli/tests/test_verify.py
+++ b/xmu-rollcall-cli/tests/test_verify.py
@@ -1,0 +1,109 @@
+import unittest
+from unittest.mock import patch
+
+from xmu_rollcall.verify import (
+    attendance_threshold_reached,
+    calculate_attendance_progress,
+    send_code,
+    send_self_registration,
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, get_response=None, put_response=None):
+        self.headers = {"User-Agent": "test"}
+        self.get_response = get_response or FakeResponse()
+        self.put_response = put_response or FakeResponse()
+        self.get_calls = []
+        self.put_calls = []
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return self.get_response
+
+    def put(self, url, **kwargs):
+        self.put_calls.append((url, kwargs))
+        return self.put_response
+
+
+class AttendanceTests(unittest.TestCase):
+    def test_calculates_signed_ratio(self):
+        progress = calculate_attendance_progress(
+            {
+                "student_rollcalls": [
+                    {"status": "on_call"},
+                    {"status": "on_call_fine"},
+                    {"status": "absent"},
+                    {"status": "absent"},
+                ]
+            }
+        )
+
+        self.assertEqual(progress, (2, 4, 0.5))
+
+    def test_waits_below_threshold_and_reuses_payload(self):
+        payload = {
+            "number_code": "1234",
+            "student_rollcalls": [
+                {"status": "on_call"},
+                {"status": "absent"},
+                {"status": "absent"},
+                {"status": "absent"},
+                {"status": "absent"},
+                {"status": "absent"},
+            ],
+        }
+        session = FakeSession(get_response=FakeResponse(payload=payload))
+
+        reached, details = attendance_threshold_reached(session, 42, 0.2)
+
+        self.assertFalse(reached)
+        self.assertIs(details, payload)
+        self.assertEqual(len(session.get_calls), 1)
+
+    def test_zero_threshold_does_not_call_api(self):
+        session = FakeSession()
+
+        reached, details = attendance_threshold_reached(session, 42, 0)
+
+        self.assertTrue(reached)
+        self.assertIsNone(details)
+        self.assertEqual(session.get_calls, [])
+
+    @patch("xmu_rollcall.verify.time.sleep")
+    def test_number_rollcall_reuses_attendance_response(self, sleep):
+        session = FakeSession()
+        details = {"number_code": "5678", "student_rollcalls": []}
+
+        result = send_code(session, 42, details)
+
+        self.assertTrue(result)
+        self.assertEqual(session.get_calls, [])
+        url, kwargs = session.put_calls[0]
+        self.assertTrue(url.endswith("/42/answer_number_rollcall"))
+        self.assertEqual(kwargs["json"]["numberCode"], "5678")
+        sleep.assert_called_once_with(5)
+
+    def test_self_registration_payload(self):
+        session = FakeSession()
+
+        result = send_self_registration(session, 99)
+
+        self.assertTrue(result)
+        url, kwargs = session.put_calls[0]
+        self.assertTrue(url.endswith("/99/answer_self_registration_rollcall"))
+        self.assertEqual(set(kwargs["json"]), {"deviceId"})
+        self.assertTrue(kwargs["json"]["deviceId"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xmu-rollcall-cli/xmu_rollcall/__init__.py
+++ b/xmu-rollcall-cli/xmu_rollcall/__init__.py
@@ -1,3 +1,3 @@
 """XMU Rollcall CLI Package"""
 
-__version__ = "3.4.1"
+__version__ = "3.5.0"

--- a/xmu-rollcall-cli/xmu_rollcall/auth.py
+++ b/xmu-rollcall-cli/xmu_rollcall/auth.py
@@ -1,0 +1,151 @@
+"""Authentication fallbacks based on imported or browser-captured cookies."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from http.cookies import CookieError, SimpleCookie
+from typing import Any, Dict, Iterable, Optional
+
+import requests
+
+BASE_URL = "https://lnt.xmu.edu.cn"
+PROFILE_URL = f"{BASE_URL}/api/profile"
+
+
+class CookieImportError(ValueError):
+    """Raised when cookie input cannot be parsed into a usable session."""
+
+
+def _set_cookie(session: requests.Session, item: Dict[str, Any]) -> None:
+    name = item.get("name")
+    value = item.get("value")
+    if not name or value is None:
+        raise CookieImportError("Cookie entries must include name and value fields.")
+
+    kwargs: Dict[str, Any] = {}
+    for key in ("domain", "path"):
+        if item.get(key):
+            kwargs[key] = item[key]
+    if item.get("secure") is not None:
+        kwargs["secure"] = bool(item["secure"])
+
+    expires = item.get("expires", item.get("expirationDate"))
+    if expires not in (None, "", -1):
+        try:
+            kwargs["expires"] = int(float(expires))
+        except (TypeError, ValueError):
+            pass
+
+    session.cookies.set(str(name), str(value), **kwargs)
+
+
+def _load_json_cookies(session: requests.Session, payload: Any) -> bool:
+    if isinstance(payload, dict) and isinstance(payload.get("cookies"), list):
+        payload = payload["cookies"]
+
+    if isinstance(payload, list):
+        for item in payload:
+            if not isinstance(item, dict):
+                raise CookieImportError("A JSON cookie list may only contain objects.")
+            _set_cookie(session, item)
+        return bool(payload)
+
+    if isinstance(payload, dict):
+        for name, value in payload.items():
+            if isinstance(value, (dict, list)):
+                raise CookieImportError(
+                    "A JSON cookie object must map cookie names directly to values."
+                )
+            session.cookies.set(str(name), str(value))
+        return bool(payload)
+
+    return False
+
+
+def session_from_cookie_input(cookie_input: str) -> requests.Session:
+    """Build a requests session from JSON exports or a raw Cookie header.
+
+    Supported JSON shapes are the bot's ``{name: value}`` cache, a browser
+    extension's list of cookie objects, and ``{"cookies": [...]}`` exports.
+    """
+
+    value = (cookie_input or "").strip()
+    if not value:
+        raise CookieImportError("Cookie input is empty.")
+
+    session = requests.Session()
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError:
+        payload = None
+
+    if payload is not None:
+        if not _load_json_cookies(session, payload):
+            raise CookieImportError("The JSON input does not contain any cookies.")
+        return session
+
+    if value.lower().startswith("cookie:"):
+        value = value.split(":", 1)[1].strip()
+
+    parsed = SimpleCookie()
+    try:
+        parsed.load(value)
+    except CookieError as exc:  # pragma: no cover - depends on stdlib parser
+        raise CookieImportError(f"Invalid Cookie header: {exc}") from exc
+
+    if not parsed:
+        raise CookieImportError(
+            "Unsupported cookie format. Use JSON or a raw 'name=value; ...' header."
+        )
+    for name, morsel in parsed.items():
+        session.cookies.set(name, morsel.value)
+    return session
+
+
+def capture_browser_session(timeout: int = 300) -> requests.Session:
+    """Open an interactive Chromium login and return its authenticated cookies."""
+
+    if sys.version_info < (3, 8):
+        raise RuntimeError("Browser login requires Python 3.8 or newer.")
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise RuntimeError(
+            "Browser login requires the optional dependency. Run "
+            "`pip install 'xmu-rollcall-cli[browser]'` and "
+            "`playwright install chromium`."
+        ) from exc
+
+    deadline = time.monotonic() + timeout
+    captured: Optional[Iterable[Dict[str, Any]]] = None
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=False)
+        context = browser.new_context()
+        page = context.new_page()
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        while time.monotonic() < deadline:
+            try:
+                response = context.request.get(PROFILE_URL, timeout=5000)
+                if response.status == 200:
+                    profile = response.json()
+                    if isinstance(profile, dict) and profile.get("name"):
+                        captured = context.cookies([BASE_URL])
+                        break
+            except Exception:
+                pass
+            page.wait_for_timeout(1000)
+
+        browser.close()
+
+    if not captured:
+        raise RuntimeError("Browser login timed out before TronClass authentication completed.")
+
+    session = requests.Session()
+    for item in captured:
+        _set_cookie(session, item)
+    return session

--- a/xmu-rollcall-cli/xmu_rollcall/cli.py
+++ b/xmu-rollcall-cli/xmu_rollcall/cli.py
@@ -1,13 +1,17 @@
 import click
 import sys
+from pathlib import Path
 from xmulogin import xmulogin
 from . import __version__
+from .auth import CookieImportError, capture_browser_session, session_from_cookie_input
 from .config import (
     load_config, save_config, is_config_complete, get_cookies_path,
     add_account, get_all_accounts, get_current_account, set_current_account,
-    get_account_by_id, CONFIG_FILE, delete_account, perform_account_deletion
+    get_account_by_id, get_attendance_threshold, CONFIG_FILE, delete_account,
+    perform_account_deletion
 )
 from .monitor import start_monitor, base_url, headers
+from .utils import save_session, verify_session
 
 # ANSI Color codes
 class Colors:
@@ -26,12 +30,13 @@ class Colors:
 def cli(ctx):
     if ctx.invoked_subcommand is None:
         click.echo(f"{Colors.OKCYAN}{Colors.BOLD}XMU Rollcall Bot CLI v{__version__}{Colors.ENDC}")
-        click.echo(f"\nUsage:")
-        click.echo(f"  xmu config    Configure credentials and add accounts")
-        click.echo(f"  xmu switch    Switch between accounts")
-        click.echo(f"  xmu start     Start monitoring rollcalls")
-        click.echo(f"  xmu refresh   Refresh the login status")
-        click.echo(f"  xmu --help    Show this message")
+        click.echo("\nUsage:")
+        click.echo("  xmu config    Configure credentials and add accounts")
+        click.echo("  xmu switch    Switch between accounts")
+        click.echo("  xmu start     Start monitoring rollcalls")
+        click.echo("  xmu auth      Import cookies or log in through a browser")
+        click.echo("  xmu refresh   Refresh the login status")
+        click.echo("  xmu --help    Show this message")
 
 @cli.command()
 def config():
@@ -88,11 +93,15 @@ def config():
                 except RuntimeError as e:
                     click.echo(f"{Colors.FAIL}✗ Failed to save configuration: {str(e)}{Colors.ENDC}")
                     click.echo(f"{Colors.WARNING}Tip: In sandboxed environments (like a-Shell), set environment variable:{Colors.ENDC}")
-                    click.echo(f"  export XMU_ROLLCALL_CONFIG_DIR=~/Documents/.xmu_rollcall")
+                    click.echo("  export XMU_ROLLCALL_CONFIG_DIR=~/Documents/.xmu_rollcall")
             else:
                 click.echo(f"{Colors.FAIL}✗ Login failed. Please check your credentials.{Colors.ENDC}")
         except Exception as e:
             click.echo(f"{Colors.FAIL}✗ Error during login validation: {str(e)}{Colors.ENDC}")
+            click.echo(
+                f"{Colors.WARNING}Fallback: use `xmu auth import` or "
+                f"`xmu auth browser`.{Colors.ENDC}"
+            )
 
     def delete_existing_account():
         """删除账号"""
@@ -152,11 +161,12 @@ def config():
         click.echo(f"{Colors.BOLD}Choose an action:{Colors.ENDC}")
         click.echo(f"  {Colors.OKCYAN}n{Colors.ENDC} - Add new account")
         click.echo(f"  {Colors.OKCYAN}d{Colors.ENDC} - Delete account")
+        click.echo(f"  {Colors.OKCYAN}t{Colors.ENDC} - Set attendance threshold")
         click.echo(f"  {Colors.OKCYAN}q{Colors.ENDC} - Quit")
 
         action = click.prompt(
             f"\n{Colors.BOLD}Action{Colors.ENDC}",
-            type=click.Choice(['n', 'd', 'q'], case_sensitive=False),
+            type=click.Choice(['n', 'd', 't', 'q'], case_sensitive=False),
             default='q'
         )
 
@@ -166,6 +176,19 @@ def config():
             add_new_account()
         elif action.lower() == 'd':
             delete_existing_account()
+        elif action.lower() == 't':
+            current_threshold = get_attendance_threshold(current_config)
+            threshold = click.prompt(
+                f"{Colors.BOLD}Attendance threshold (0 to 1){Colors.ENDC}",
+                type=click.FloatRange(0, 1),
+                default=current_threshold,
+            )
+            current_config["attendance_threshold"] = threshold
+            save_config(current_config)
+            click.echo(
+                f"{Colors.OKGREEN}✓ Attendance threshold set to "
+                f"{threshold:.0%}.{Colors.ENDC}\n"
+            )
         elif action.lower() == 'q':
             # 退出前显示最终账号列表
             accounts = get_all_accounts(current_config)
@@ -180,7 +203,13 @@ def config():
             break
 
 @cli.command()
-def start():
+@click.option(
+    "--attendance-threshold",
+    type=click.FloatRange(0, 1),
+    default=None,
+    help="Fraction of classmates who must sign first (default: configured 20%).",
+)
+def start(attendance_threshold):
     """启动签到监控"""
     # 加载配置
     config_data = load_config()
@@ -193,11 +222,17 @@ def start():
 
     # 获取当前账号
     current_account = get_current_account(config_data)
+    if attendance_threshold is None:
+        attendance_threshold = get_attendance_threshold(config_data)
     click.echo(f"{Colors.OKCYAN}Using account: {current_account.get('name') or current_account.get('username')} (ID: {current_account.get('id')}){Colors.ENDC}")
+    click.echo(
+        f"{Colors.OKCYAN}Attendance threshold: "
+        f"{attendance_threshold:.0%}{Colors.ENDC}"
+    )
 
     # 启动监控
     try:
-        start_monitor(current_account)
+        start_monitor(current_account, attendance_threshold)
     except KeyboardInterrupt:
         click.echo(f"\n{Colors.WARNING}Shutting down...{Colors.ENDC}")
         sys.exit(0)
@@ -275,6 +310,121 @@ def switch():
     else:
         click.echo(f"{Colors.FAIL}✗ Account not found!{Colors.ENDC}")
         sys.exit(1)
+
+
+def _persist_authenticated_session(config_data, session, account_id=None):
+    profile = verify_session(session)
+    if not profile:
+        raise RuntimeError(
+            "The imported session could not access /api/profile. "
+            "Check that the cookies belong to lnt.xmu.edu.cn and are not expired."
+        )
+
+    account = None
+    explicit_account = account_id is not None
+    if account_id is not None:
+        account = get_account_by_id(config_data, account_id)
+        if account is None:
+            raise RuntimeError(f"Account ID {account_id} does not exist.")
+    else:
+        account = get_current_account(config_data)
+
+    name = profile.get("name") or profile.get("nickname") or "Cookie account"
+    profile_identity = (
+        profile.get("user_no")
+        or profile.get("username")
+        or profile.get("email")
+    )
+    username = profile_identity or (account and account.get("username")) or name
+
+    if (
+        account is not None
+        and not explicit_account
+        and profile_identity
+        and account.get("username")
+        and str(account["username"]) != str(profile_identity)
+    ):
+        account = None
+
+    if account is None:
+        account_id = add_account(config_data, username, "", name)
+        account = get_account_by_id(config_data, account_id)
+        set_current_account(config_data, account_id)
+    else:
+        account_id = account["id"]
+        account["name"] = name
+        if not account.get("username"):
+            account["username"] = username
+
+    cookies_path = get_cookies_path(account_id)
+    if not save_session(session, cookies_path):
+        raise RuntimeError(f"Failed to save cookies to {cookies_path}.")
+    save_config(config_data)
+    return account, cookies_path
+
+
+@cli.group()
+def auth():
+    """Authenticate with imported cookies or an interactive browser."""
+
+
+@auth.command(name="import")
+@click.option(
+    "--file",
+    "file_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Read cookies from a JSON or text file instead of prompting.",
+)
+@click.option("--account-id", type=int, help="Replace cookies for this account ID.")
+def import_cookies(file_path, account_id):
+    """Import a JSON cookie export or raw Cookie header."""
+    try:
+        if file_path:
+            cookie_input = file_path.read_text(encoding="utf-8")
+        else:
+            cookie_input = click.prompt(
+                "Paste cookie JSON or a raw Cookie header",
+                hide_input=True,
+            )
+        session = session_from_cookie_input(cookie_input)
+        account, cookies_path = _persist_authenticated_session(
+            load_config(), session, account_id
+        )
+    except (CookieImportError, OSError, RuntimeError) as exc:
+        raise click.ClickException(str(exc))
+
+    click.echo(
+        f"{Colors.OKGREEN}✓ Cookies imported for "
+        f"{account.get('name') or account.get('username')}.{Colors.ENDC}"
+    )
+    click.echo(f"{Colors.GRAY}Cookie cache: {cookies_path}{Colors.ENDC}")
+
+
+@auth.command(name="browser")
+@click.option("--account-id", type=int, help="Replace cookies for this account ID.")
+@click.option(
+    "--timeout",
+    type=click.IntRange(30, 1800),
+    default=300,
+    show_default=True,
+    help="Seconds to wait for browser login.",
+)
+def browser_login(account_id, timeout):
+    """Open Chromium, wait for login, and capture the resulting cookies."""
+    click.echo("Opening Chromium. Complete XMU login in the browser window...")
+    try:
+        session = capture_browser_session(timeout)
+        account, cookies_path = _persist_authenticated_session(
+            load_config(), session, account_id
+        )
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc))
+
+    click.echo(
+        f"{Colors.OKGREEN}✓ Browser login captured for "
+        f"{account.get('name') or account.get('username')}.{Colors.ENDC}"
+    )
+    click.echo(f"{Colors.GRAY}Cookie cache: {cookies_path}{Colors.ENDC}")
 
 
 if __name__ == '__main__':

--- a/xmu-rollcall-cli/xmu_rollcall/config.py
+++ b/xmu-rollcall-cli/xmu_rollcall/config.py
@@ -35,10 +35,12 @@ def get_config_dir():
 
 CONFIG_DIR = get_config_dir()
 CONFIG_FILE = CONFIG_DIR / "config.json"
+DEFAULT_ATTENDANCE_THRESHOLD = 0.2
 
 DEFAULT_CONFIG = {
     "accounts": [],
-    "current_account_id": None
+    "current_account_id": None,
+    "attendance_threshold": DEFAULT_ATTENDANCE_THRESHOLD,
 }
 
 DEFAULT_ACCOUNT = {
@@ -47,6 +49,15 @@ DEFAULT_ACCOUNT = {
     "username": "",
     "password": ""
 }
+
+
+def new_default_config():
+    """Return a fresh default so callers never share the accounts list."""
+    return {
+        "accounts": [],
+        "current_account_id": None,
+        "attendance_threshold": DEFAULT_ATTENDANCE_THRESHOLD,
+    }
 
 def ensure_config_dir():
     """确保配置目录存在"""
@@ -75,20 +86,26 @@ def load_config():
                                 "username": old_username,
                                 "password": old_password
                             }],
-                            "current_account_id": 1
+                            "current_account_id": 1,
+                            "attendance_threshold": DEFAULT_ATTENDANCE_THRESHOLD,
                         }
                         return new_config
-                    return DEFAULT_CONFIG.copy()
+                    return new_default_config()
+                config.setdefault("attendance_threshold", DEFAULT_ATTENDANCE_THRESHOLD)
                 return config
         except Exception:
-            return DEFAULT_CONFIG.copy()
-    return DEFAULT_CONFIG.copy()
+            return new_default_config()
+    return new_default_config()
 
 def save_config(config):
     """保存配置文件"""
     ensure_config_dir()
     with open(CONFIG_FILE, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2, ensure_ascii=False)
+    try:
+        os.chmod(CONFIG_FILE, 0o600)
+    except OSError:
+        pass
 
 def get_next_account_id(config):
     """获取下一个可用的账号ID"""
@@ -141,8 +158,24 @@ def is_config_complete(config):
     current_account = get_current_account(config)
     if current_account is None:
         return False
-    required_fields = ["username", "password"]
-    return all(current_account.get(field) for field in required_fields)
+    has_credentials = all(
+        current_account.get(field) for field in ("username", "password")
+    )
+    has_cookies = os.path.exists(get_cookies_path(current_account.get("id")))
+    return has_credentials or has_cookies
+
+
+def get_attendance_threshold(config):
+    """Return a validated attendance threshold between zero and one."""
+    try:
+        threshold = float(
+            config.get("attendance_threshold", DEFAULT_ATTENDANCE_THRESHOLD)
+        )
+    except (TypeError, ValueError):
+        return DEFAULT_ATTENDANCE_THRESHOLD
+    if 0 <= threshold <= 1:
+        return threshold
+    return DEFAULT_ATTENDANCE_THRESHOLD
 
 def get_cookies_path(account_id=None):
     """获取cookies文件路径，根据账号ID命名"""
@@ -226,4 +259,3 @@ def perform_account_deletion(cookies_to_delete, cookies_to_rename):
             if os.path.exists(new_path):
                 os.remove(new_path)
             os.rename(old_path, new_path)
-

--- a/xmu-rollcall-cli/xmu_rollcall/monitor.py
+++ b/xmu-rollcall-cli/xmu_rollcall/monitor.py
@@ -51,7 +51,7 @@ def get_terminal_width():
     """获取终端宽度"""
     try:
         return shutil.get_terminal_size().columns
-    except:
+    except OSError:
         return 80
 
 _ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
@@ -201,10 +201,10 @@ def update_footer_text():
     sys.stdout.write("\033[?25h")
     sys.stdout.flush()
 
-def start_monitor(account):
+def start_monitor(account, attendance_threshold=0.2):
     """启动监控程序"""
-    USERNAME = account['username']
-    PASSWORD = account['password']
+    USERNAME = account.get('username', '')
+    PASSWORD = account.get('password', '')
     ACCOUNT_ID = account.get('id', 1)
     ACCOUNT_NAME = account.get('name', '')
     # LATITUDE = account.get('latitude', 0)
@@ -239,6 +239,14 @@ def start_monitor(account):
             print_login_status("Failed to load session", False)
 
     if not session:
+        if not USERNAME or not PASSWORD:
+            print_login_status(
+                "Cached cookies are missing or expired. Run `xmu auth import` "
+                "or `xmu auth browser` to authenticate again.",
+                False,
+            )
+            time.sleep(2)
+            sys.exit(1)
         print(f"{Colors.OKCYAN}[Step 2/3]{Colors.ENDC} Logging in with credentials...")
         time.sleep(2)
         session = xmulogin(type=3, username=USERNAME, password=PASSWORD)
@@ -304,7 +312,11 @@ def start_monitor(account):
                             print(f"\n{Colors.WARNING}{Colors.BOLD}{'!' * width}{Colors.ENDC}")
                             print(center_text(f"{Colors.WARNING}{Colors.BOLD}NEW ROLLCALL DETECTED{Colors.ENDC}"))
                             print(f"{Colors.WARNING}{Colors.BOLD}{'!' * width}{Colors.ENDC}\n")
-                            temp_data = process_rollcalls(temp_data, session)
+                            temp_data = process_rollcalls(
+                                temp_data,
+                                session,
+                                attendance_threshold,
+                            )
                             print_separator("=")
                             print(f"\n{center_text(f'{Colors.GRAY}Press Ctrl+C to exit, continuing monitor...{Colors.ENDC}')}\n")
                             try:

--- a/xmu-rollcall-cli/xmu_rollcall/rollcall_handler.py
+++ b/xmu-rollcall-cli/xmu_rollcall/rollcall_handler.py
@@ -1,10 +1,15 @@
 import time
-from .verify import send_code, send_radar
+from .verify import (
+    attendance_threshold_reached,
+    send_code,
+    send_radar,
+    send_self_registration,
+)
 
-def process_rollcalls(data, session):
+def process_rollcalls(data, session, attendance_threshold=0.2):
     """处理签到数据"""
     data_empty = {'rollcalls': []}
-    result = handle_rollcalls(data, session)
+    result = handle_rollcalls(data, session, attendance_threshold)
     if False in result:
         return data_empty
     else:
@@ -12,39 +17,58 @@ def process_rollcalls(data, session):
 
 def extract_rollcalls(data):
     """提取签到信息"""
-    rollcalls = data['rollcalls']
+    rollcalls = data.get('rollcalls', [])
     result = []
     if rollcalls:
         rollcall_count = len(rollcalls)
         for rollcall in rollcalls:
+            details = rollcall.get('rollcall')
+            if not isinstance(details, dict):
+                details = rollcall
+
+            def value(key, default=None):
+                outer_value = rollcall.get(key)
+                if outer_value is not None:
+                    return outer_value
+                return details.get(key, default)
+
             result.append({
-                'course_title': rollcall['course_title'],
-                'created_by_name': rollcall['created_by_name'],
-                'department_name': rollcall['department_name'],
-                'is_expired': rollcall['is_expired'],
-                'is_number': rollcall['is_number'],
-                'is_radar': rollcall['is_radar'],
-                'rollcall_id': rollcall['rollcall_id'],
-                'rollcall_status': rollcall['rollcall_status'],
-                'scored': rollcall['scored'],
-                'status': rollcall['status']
+                'course_title': value('course_title', ''),
+                'created_by_name': value('created_by_name', ''),
+                'department_name': value('department_name', ''),
+                'is_expired': value('is_expired', False),
+                'is_number': value('is_number', False),
+                'is_radar': value('is_radar', False),
+                'rollcall_id': value('rollcall_id', value('id')),
+                'rollcall_status': value('rollcall_status', ''),
+                'scored': value('scored', False),
+                'source': value('source', ''),
+                'type': value('type', ''),
+                'status': value('status', '')
             })
     else:
         rollcall_count = 0
     return rollcall_count, result
 
-def handle_rollcalls(data, session):
+def handle_rollcalls(data, session, attendance_threshold=0.2):
     """处理签到流程"""
     count, rollcalls = extract_rollcalls(data)
     answer_status = [False for _ in range(count)]
 
     if count:
-        print(time.strftime("%H:%M:%S", time.localtime()), f"New rollcall(s) found!\n")
+        print(time.strftime("%H:%M:%S", time.localtime()), "New rollcall(s) found!\n")
         for i in range(count):
             print(f"{i+1} of {count}:")
             print(f"Course name: {rollcalls[i]['course_title']}, rollcall created by {rollcalls[i]['department_name']} {rollcalls[i]['created_by_name']}.")
 
-            if rollcalls[i]['is_radar']:
+            is_self_registration = (
+                rollcalls[i]['source'] == 'manual'
+                and rollcalls[i]['type'] == 'self_registration'
+            )
+
+            if is_self_registration:
+                temp_str = "Self-registration rollcall"
+            elif rollcalls[i]['is_radar']:
                 temp_str = "Radar rollcall"
             elif rollcalls[i]['is_number']:
                 temp_str = "Number rollcall"
@@ -52,22 +76,46 @@ def handle_rollcalls(data, session):
                 temp_str = "QRcode rollcall"
             print(f"Rollcall type: {temp_str}\n")
 
-            if (rollcalls[i]['status'] == 'absent') & (rollcalls[i]['is_number']) & (not rollcalls[i]['is_radar']):
-                if send_code(session, rollcalls[i]['rollcall_id']):
+            if rollcalls[i]['status'] in ('on_call', 'on_call_fine'):
+                print("Already answered.")
+                answer_status[i] = True
+                continue
+
+            is_number_rollcall = (
+                rollcalls[i]['status'] == 'absent'
+                and rollcalls[i]['is_number']
+                and not rollcalls[i]['is_radar']
+            )
+            is_supported = (
+                is_self_registration
+                or is_number_rollcall
+                or rollcalls[i]['is_radar']
+            )
+            if not is_supported:
+                print("Answering failed. QRcode rollcall not supported yet.")
+                continue
+
+            threshold_reached, details = attendance_threshold_reached(
+                session,
+                rollcalls[i]['rollcall_id'],
+                attendance_threshold,
+            )
+            if not threshold_reached:
+                continue
+
+            if is_self_registration:
+                if send_self_registration(session, rollcalls[i]['rollcall_id']):
                     answer_status[i] = True
                 else:
                     print("Answering failed.")
-            elif rollcalls[i]['status'] == 'on_call_fine':
-                print("Already answered.")
-                answer_status[i] = True
+            elif is_number_rollcall:
+                if send_code(session, rollcalls[i]['rollcall_id'], details):
+                    answer_status[i] = True
+                else:
+                    print("Answering failed.")
             elif rollcalls[i]['is_radar']:
                 if send_radar(session, rollcalls[i]['rollcall_id']):
                     answer_status[i] = True
                 else:
                     print("Answering failed.")
-            else:
-                # TODO: qrcode rollcall
-                print("Answering failed. QRcode rollcall not supported yet.")
-
     return answer_status
-

--- a/xmu-rollcall-cli/xmu_rollcall/utils.py
+++ b/xmu-rollcall-cli/xmu_rollcall/utils.py
@@ -24,8 +24,13 @@ def save_session(sess: requests.Session, path: str):
         cj_dict = requests.utils.dict_from_cookiejar(sess.cookies)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(cj_dict, f)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return True
     except Exception:
-        pass
+        return False
 
 def load_session(sess: requests.Session, path: str):
     """从文件加载session"""
@@ -48,4 +53,3 @@ def verify_session(sess: requests.Session) -> dict:
     except Exception:
         pass
     return {}
-

--- a/xmu-rollcall-cli/xmu_rollcall/verify.py
+++ b/xmu-rollcall-cli/xmu_rollcall/verify.py
@@ -15,6 +15,74 @@ headers = {
     "Referer": "https://ids.xmu.edu.cn/authserver/login",
 }
 
+SIGNED_ATTENDANCE_STATUSES = {"on_call", "on_call_fine"}
+
+
+def fetch_rollcall_details(in_session, rollcall_id):
+    """Fetch the rollcall detail payload used for attendance and number codes."""
+    url = f"{base_url}/api/rollcall/{rollcall_id}/student_rollcalls"
+    try:
+        response = in_session.get(url, headers=in_session.headers, timeout=15)
+        if response.status_code != 200:
+            print(f"Failed to get attendance status. HTTP {response.status_code}.")
+            return None
+        payload = response.json()
+        if not isinstance(payload, dict):
+            print("Failed to get attendance status. Unexpected response format.")
+            return None
+        return payload
+    except (requests.RequestException, ValueError) as exc:
+        print(f"Failed to get attendance status: {exc}")
+        return None
+
+
+def calculate_attendance_progress(data):
+    """Return ``(signed, total, ratio)`` for a student_rollcalls response."""
+    if not isinstance(data, dict):
+        return None
+    students = data.get("student_rollcalls")
+    if not isinstance(students, list) or not students:
+        return None
+
+    signed = sum(
+        1
+        for student in students
+        if isinstance(student, dict)
+        and str(student.get("status", "")).lower() in SIGNED_ATTENDANCE_STATUSES
+    )
+    total = len(students)
+    return signed, total, signed / total
+
+
+def attendance_threshold_reached(in_session, rollcall_id, threshold):
+    """Check whether enough classmates have answered.
+
+    The detail payload is returned as the second value so number rollcalls can
+    reuse it instead of immediately querying the same endpoint again.
+    """
+    if threshold <= 0:
+        return True, None
+
+    details = fetch_rollcall_details(in_session, rollcall_id)
+    progress = calculate_attendance_progress(details)
+    if progress is None:
+        print("Attendance progress is unavailable; waiting before answering.")
+        return False, details
+
+    signed, total, ratio = progress
+    if ratio < threshold:
+        print(
+            f"Waiting for attendance threshold: {signed}/{total} "
+            f"({ratio:.0%}), target {threshold:.0%}."
+        )
+        return False, details
+
+    print(
+        f"Attendance threshold reached: {signed}/{total} "
+        f"({ratio:.0%}), target {threshold:.0%}."
+    )
+    return True, details
+
 def find_number_code(data, depth=0, max_depth=10):
     """Extract number_code from nested dict/list API responses.
 
@@ -43,26 +111,15 @@ def find_number_code(data, depth=0, max_depth=10):
                 return nested_code
     return None
 
-def send_code(in_session, rollcall_id):
-    code_url = f"{base_url}/api/rollcall/{rollcall_id}/student_rollcalls"
+def send_code(in_session, rollcall_id, rollcall_details=None):
     answer_url = f"{base_url}/api/rollcall/{rollcall_id}/answer_number_rollcall"
     print("Trying number code from API...")
     t00 = time.time()
     request_headers = in_session.headers
-    try:
-        code_response = in_session.get(code_url, headers=request_headers)
-        if code_response.status_code != 200:
-            t01 = time.time()
-            print(f"Failed to get number code. Status: {code_response.status_code}\nTime: {t01 - t00:.2f} s.")
-            return False
-        code_data = code_response.json()
-    except requests.RequestException as e:
+    code_data = rollcall_details or fetch_rollcall_details(in_session, rollcall_id)
+    if code_data is None:
         t01 = time.time()
-        print(f"Failed to request number code API: {e}\nTime: {t01 - t00:.2f} s.")
-        return False
-    except ValueError as e:
-        t01 = time.time()
-        print(f"Failed to parse number code API response: {e}\nTime: {t01 - t00:.2f} s.")
+        print(f"Failed to get number code.\nTime: {t01 - t00:.2f} s.")
         return False
 
     number_code = find_number_code(code_data)
@@ -76,7 +133,12 @@ def send_code(in_session, rollcall_id):
         "numberCode": number_code
     }
     try:
-        response = in_session.put(answer_url, json=payload, headers=request_headers)
+        response = in_session.put(
+            answer_url,
+            json=payload,
+            headers=request_headers,
+            timeout=15,
+        )
         if response.status_code == 200:
             print("Number code rollcall answered successfully.\nNumber code: ", number_code)
             time.sleep(5)
@@ -90,6 +152,24 @@ def send_code(in_session, rollcall_id):
         t01 = time.time()
         print(f"Failed to submit number code: {e}\nTime: {t01 - t00:.2f} s.")
         return False
+
+
+def send_self_registration(in_session, rollcall_id):
+    """Answer a manual self-registration rollcall."""
+    url = f"{base_url}/api/rollcall/{rollcall_id}/answer_self_registration_rollcall"
+    payload = {"deviceId": str(uuid.uuid4())}
+    try:
+        response = in_session.put(url, json=payload, headers=in_session.headers, timeout=15)
+    except requests.RequestException as exc:
+        print(f"Failed to submit self-registration rollcall: {exc}")
+        return False
+
+    if response.status_code == 200:
+        print("Self-registration rollcall answered successfully.")
+        return True
+
+    print(f"Failed to submit self-registration rollcall. HTTP {response.status_code}.")
+    return False
 
 def send_radar(in_session, rollcall_id):
     url = f"{base_url}/api/rollcall/{rollcall_id}/answer"


### PR DESCRIPTION
## Summary

- add cookie import from JSON/browser exports or a raw Cookie header
- add an optional interactive Chromium login flow that captures the authenticated TronClass session
- wait until a configurable share of classmates has signed before answering (20% by default)
- add manual self-registration rollcall detection and submission
- preserve cookie-only accounts, restrict local config/cookie file permissions, and document all fallback flows
- bump the package to 3.5.0 so the main-branch PyPI workflow can publish the release

## Why

Password login can be interrupted by upstream authentication challenges, so users need session-based fallbacks that also work when direct login is unavailable. The previous monitor also answered immediately and treated manual self-registration as an unsupported QR rollcall.

The attendance check fails closed: when `student_rollcalls` is unavailable or malformed, the bot waits and retries instead of signing early. It currently counts `on_call` and `on_call_fine` as signed states. A sanitized real response sample has been requested in issue #29 to validate additional edge cases.

## User impact

- `xmu auth import --file cookies.json` imports an existing authenticated session
- `xmu auth browser` opens the official login page after installing the `browser` extra
- `xmu start --attendance-threshold 0.3` overrides the configured threshold; `0` disables the delay
- manual `self_registration` rollcalls are answered through the dedicated endpoint

## Validation

- 14 unit tests
- Ruff checks
- Python bytecode compilation
- source distribution and wheel build
- Twine package metadata checks
- clean-wheel installation and CLI help smoke tests

Closes #28
Closes #29
Closes #30
